### PR TITLE
Add individual user's contribution history page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { Route, Switch, BrowserRouter} from 'react-router-dom';
 import Conduct from './pages/Conduct.js';
 // import Leaderboard from './pages/leaderboard/Leaderboard';
 import Leaderboard from './pages/leaderboard_temp';
+import Points from './pages/points';
 import Project from './pages/Project';
 import Team from './pages/teamnew'
 import Reward from './pages/Reward/reward';
@@ -24,6 +25,7 @@ function App() {
           <Route exact path="/" component={Home}/>
           <Route path="/register" component={Conduct}/>
           <Route path="/leaderboard" component={Leaderboard} />
+          <Route path="/points/:id" component={Points} />
           <Route path="/project" component={Project} />
           <Route path="/team" component={Team} />
           <Route path="/reward" component={Reward} />

--- a/src/pages/leaderboard/Leaderboard.jsx
+++ b/src/pages/leaderboard/Leaderboard.jsx
@@ -7,6 +7,7 @@ import Footer from "../../components/footer";
 import { usePagination, useTable } from "react-table";
 import { Dropdown } from "react-bootstrap";
 import Loading from "../../components/leaderboard/Loading";
+import { Link } from 'react-router-dom';
 
 const Leaderboard = () => {
 
@@ -19,7 +20,7 @@ const Leaderboard = () => {
     async function getCSV() {
       try{
         const tempfi = [];
-        const target = `https://docs.google.com/spreadsheets/d/e/2PACX-1vQbBtmoTx9NEqcob94XXoIMnorCXObHA7wb84DOhJ5-Qaoxq38Az5Gh8Uk_FHuB5J-uUgLb8RNBpwUO/pub?gid=0&single=true&output=csv`;
+        const target = `https://docs.google.com/spreadsheets/d/1dqrF2ixN21yvUjPs6ZL5btvNP0V8q1v9vX4RjFKFEX4/export?format=csv`;
         const result = await fetch(target);
         const data = await result.text();
         var rows = data.toString().split("\r");
@@ -277,7 +278,7 @@ const Leaderboard = () => {
                         else
                           return (
                             <td {...cell.getCellProps()}>
-                              {cell["value"]}
+                              <Link to={'/points/' + cell["value"]}>{cell["value"]}</Link>
                             </td>
                           );
                       })}

--- a/src/pages/leaderboard/Leaderboard.jsx
+++ b/src/pages/leaderboard/Leaderboard.jsx
@@ -20,7 +20,7 @@ const Leaderboard = () => {
     async function getCSV() {
       try{
         const tempfi = [];
-        const target = `https://docs.google.com/spreadsheets/d/1dqrF2ixN21yvUjPs6ZL5btvNP0V8q1v9vX4RjFKFEX4/export?format=csv`;
+        const target = `https://docs.google.com/spreadsheets/d/e/2PACX-1vQbBtmoTx9NEqcob94XXoIMnorCXObHA7wb84DOhJ5-Qaoxq38Az5Gh8Uk_FHuB5J-uUgLb8RNBpwUO/pub?gid=0&single=true&output=csv`;
         const result = await fetch(target);
         const data = await result.text();
         var rows = data.toString().split("\r");

--- a/src/pages/points.js
+++ b/src/pages/points.js
@@ -1,0 +1,21 @@
+import React from "react";
+import Animatedbg from "../components/Animatedbg";
+import Navigation from "../components/Navigation";
+import Footer from '../components/footer';
+import Points from './points/Points.jsx';
+import "bootstrap/dist/css/bootstrap.min.css";
+
+function Pointstemp(props){
+    const {id} = props.match.params
+    return<> 
+     <Animatedbg />
+     <Navigation />
+     
+    {/* <div style={{display:"flex",alignItems:'center', justifyContent:'center', width:"100vw",height:"100vh"}}><h2 style={{color:"white",fontSize:"50px"}}>Coming Soon</h2>   
+    </div> */}
+    <Points id={id} />
+    <Footer/>
+     </>;
+  
+}
+export default Pointstemp;

--- a/src/pages/points/Points.jsx
+++ b/src/pages/points/Points.jsx
@@ -1,0 +1,95 @@
+import React, { useMemo, useState, useEffect } from "react";
+import Navigation from "../../components/Navigation";
+import style from "../leaderboard/Leaderboard.css";
+import Container from "react-bootstrap/Container";
+import Footer from "../../components/footer";
+
+import Loading from "../../components/leaderboard/Loading";
+
+const Points = (props) => {
+    const [loading, setLoading] = useState(true);
+    const [incorrectId, setIncorrectId] = useState(true);
+    const [totalPoints, setTotal] = useState(0);
+    const [points, setPoints] = useState([]);
+    const [categories, setCategories] = useState([]);
+    const [links, setLinks] = useState([]);
+
+    useEffect(() => {
+
+    async function getCSV() {
+      try{
+        const target = `https://docs.google.com/spreadsheets/d/1dqrF2ixN21yvUjPs6ZL5btvNP0V8q1v9vX4RjFKFEX4/export?format=csv`;
+        const result = await fetch(target);
+        const data = await result.text();
+        var rows = data.toString().split("\r");
+        for(let i = 0; i < rows.length ; i++){
+            const args = rows[i].split(',');
+            if (args[0] == props.id) {
+                setTotal(args[1]);
+                setIncorrectId(false);
+                let tempPoints = [];
+                let tempCate = [];
+                let tempLink = [];
+                for (let j = 2; j < args.length; j += 2) {
+                    if (j+1 == args.length) break;
+
+                    if (args[j] == '' || args[j+1] == '') {
+                        continue;
+                    }
+
+                    tempPoints.push(args[j]);
+                    tempLink.push(args[j+1]);
+                    if (args[j+1].includes("pull")) {
+                        tempCate.push("pull");
+                    } else {
+                        tempCate.push("issue");
+                    }
+                }
+                setPoints(tempPoints);
+                setCategories(tempCate);
+                setLinks(tempLink);
+            }
+        }
+        setLoading(false);
+      }catch(error){
+
+        console.log(error);
+
+      }
+    }
+
+    getCSV();
+
+  },[]);
+
+  const entries = [];
+  for (let i = 0; i < points.length; i++) {
+    entries.push(<div className="title" key={i}>{ points[i] + ((categories[i] == 'pull') ? ' (PR): ' : " (Issue): ") + links[i] }</div>)
+  }
+
+  return (
+    <>
+      <Navigation />
+      <div class='leader-stars'></div>
+      <div class='leader-twinkling'></div>
+      <div style={style} >
+        <div className='space'></div>
+        <div className='title mb-5 p-3'>{props.id}</div>
+        <div className='title mb-5 p-3'>{"Total: " + totalPoints}</div>
+        {loading ? <Loading/>: (
+
+        <Container>
+            {incorrectId ? <p>{"Wrong ID"}</p> : <ul>
+                    {entries}
+                </ul>}
+        </Container>
+         )}
+        <div className='space'></div>
+        <Footer bg='#12263F' />
+      </div>
+      {/* <ScrollButton /> */}
+    </>
+  );
+};
+
+export default Points;

--- a/src/pages/points/Points.jsx
+++ b/src/pages/points/Points.jsx
@@ -18,7 +18,7 @@ const Points = (props) => {
 
     async function getCSV() {
       try{
-        const target = `https://docs.google.com/spreadsheets/d/1dqrF2ixN21yvUjPs6ZL5btvNP0V8q1v9vX4RjFKFEX4/export?format=csv`;
+        const target = `https://docs.google.com/spreadsheets/d/e/2PACX-1vQbBtmoTx9NEqcob94XXoIMnorCXObHA7wb84DOhJ5-Qaoxq38Az5Gh8Uk_FHuB5J-uUgLb8RNBpwUO/pub?gid=0&single=true&output=csv`;
         const result = await fetch(target);
         const data = await result.text();
         var rows = data.toString().split("\r");


### PR DESCRIPTION
To avoid points conflict like last time, I have added a page to list all the contributions.

Contributions are to be listed in the excel file like this:
![image](https://user-images.githubusercontent.com/37345795/199819639-4edd982e-e057-4f1c-8a16-577926ffa32e.png)

Github handles in the leaderboard page are now clickable.

I am not very good at frontend, so someone will have to make this page's UI. You can add different icon (PR or Issue) against each contribution instead of (PR) or (Issue) text.
![5b658556c917dae4452b39bf0ba803396c8c2179](https://user-images.githubusercontent.com/37345795/199820270-c06ceb22-cb27-4219-a042-f883f348099a.jpg)
